### PR TITLE
Adding a second owner for code review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @sBuiltaJr will be requested for
 # review when someone opens a pull request.
-*       @sBuiltaJr 
+*       @sBuiltaJr @CrowCrowAI


### PR DESCRIPTION
This no-self review requirement is stupid.  Maybe I have to bot my own account at some point.